### PR TITLE
Omitdefaultlib

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -238,6 +238,7 @@
 			"NoFramePointer",
 			"NoImplicitLink",
 			"NoImportLib",
+			"OmitDefaultLibrary",
 			"NoIncrementalLink",
 			"NoManifest",
 			"NoMinimalRebuild",

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -297,6 +297,7 @@
 		"omitFramePointers",
 		"stringPooling",
 		"runtimeLibrary",
+		"omitDefaultLib",
 		"exceptionHandling",
 		"runtimeTypeInfo",
 		"bufferSecurityCheck",
@@ -1098,6 +1099,11 @@
 		end
 	end
 
+	function vc2010.omitDefaultLib(cfg)
+		if cfg.flags.OmitDefaultLibrary then
+			_p(3,'<OmitDefaultLibName>true</OmitDefaultLibName>')
+		end
+	end
 
 	function vc2010.runtimeTypeInfo(cfg)
 		if cfg.flags.NoRTTI and not cfg.flags.Managed then

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -28,6 +28,7 @@
 		flags = {
 			SEH = "/EHa",
 			Symbols = "/Z7",
+			OmitDefaultLibrary = "/Zl",
 		},
 		optimize = {
 			Off = "/Od",


### PR DESCRIPTION
Added an OmitDefaultLibrary option.

This is necessary to build libs that don't complain about conflicts with their particular version of the CRT whenever they are used.
