### PR TITLE
fix bug

### DIFF
--- a/src/host/os_rmdir.c
+++ b/src/host/os_rmdir.c
@@ -16,7 +16,7 @@ int os_rmdir(lua_State* L)
 #if PLATFORM_WINDOWS
 	z = RemoveDirectory(path);
 #else
-	z = rmdir(path);
+	z = (0==rmdir(path));
 #endif
 
 	if (!z)


### PR DESCRIPTION
rmdir() On success, zero is returned. On error, -1 is returned.
RemoveDirectory() on error,zero is returned.
